### PR TITLE
Update the mailing list information

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ setup and maintain an instance of [Grafana](https://grafana.com/) displaying
 [Linux Kernel CI reports](https://staging.kernelci.org:3000/) stored in a
 [KCIDB](https://github.com/kernelci/kcidb/) database.
 
-Write to [kernelci@groups.io](mailto:kernelci@groups.io) if you want to start
+Write to [kernelci@lists.linux.dev](mailto:kernelci@lists.linux.dev) if you want to start
 submitting results from your CI system, or if you want to receive automatic
 notifications of arriving results.
 

--- a/dashboards/Home.json
+++ b/dashboards/Home.json
@@ -20,7 +20,7 @@
   "links": [],
   "panels": [
     {
-      "content": "Welcome to Linux Kernel CI report database (**KCIDB**) dashboard.\nHere you can find testing reports aggregated from multiple CI systems (\"**origins**\").\nThis is a work in progress, and we welcome contributions and participation.\nSee the source code for [the collection system][kcidb], and for [this dashboard][kcidb-grafana].\nWrite to [kernelci@groups.io][maillist] if you want to start submitting results from your CI system,\nor if you want to receive customized notifications of arriving results.\n\n[kcidb]: https://github.com/kernelci/kcidb/\n[kcidb-grafana]: https://github.com/kernelci/kcidb-grafana/\n[maillist]: mailto:kernelci@groups.io",
+      "content": "Welcome to Linux Kernel CI report database (**KCIDB**) dashboard.\nHere you can find testing reports aggregated from multiple CI systems (\"**origins**\").\nThis is a work in progress, and we welcome contributions and participation.\nSee the source code for [the collection system][kcidb], and for [this dashboard][kcidb-grafana].\nWrite to [kernelci@lists.linux.dev][maillist] if you want to start submitting results from your CI system,\nor if you want to receive customized notifications of arriving results.\n\n[kcidb]: https://github.com/kernelci/kcidb/\n[kcidb-grafana]: https://github.com/kernelci/kcidb-grafana/\n[maillist]: mailto:kernelci@lists.linux.dev",
       "datasource": null,
       "gridPos": {
         "h": 3,


### PR DESCRIPTION
kernelci@groups.io mailing list is no longer in use and is replaced by kernelci@lists.linux.dev.

Update the mailing list information to reflect the same.